### PR TITLE
README: correct naming of command characteristic

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ COMMISSION_SERVICE_UUID = f"0000a000-{BASE_UUID}"
 - List of `ssid` and `signal`
 
 #### COMMAND (Write)
-- UUID: `CONNECT_CHARACTERISTIC_UUID = f"0000a020{BASE_UUID}"`
+- UUID: `COMMAND_CHARACTERISTIC_UUID = f"0000a020{BASE_UUID}"`
 - Example JSON string:
     ```json
     {


### PR DESCRIPTION
Code uses COMMAND_CHARACTERISTIC_UUID definition instead of CONNECT_*. Change the readme accordingly.